### PR TITLE
Highlight classes without names.

### DIFF
--- a/CoffeeScript.tmLanguage
+++ b/CoffeeScript.tmLanguage
@@ -397,6 +397,32 @@
 			<key>name</key>
 			<string>variable.language.coffee</string>
 		</dict>
+		<!-- Syntax highlighting for classes with inheritance, but without names -->
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.class.coffee</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.inheritance.coffee</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.inherited-class.coffee</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(class\b)\s+(extends)\s+(@?[a-zA-Z\$\._][\w\.]*)?</string>
+			<key>name</key>
+			<string>meta.unnamed_class.coffee</string>
+		</dict>
+		<!-- Syntax highlighting for classes with names -->
 		<dict>
 			<key>captures</key>
 			<dict>


### PR DESCRIPTION
Previously the highlighter would not highlight `class extends parentClass` which is valid coffeescript
